### PR TITLE
Fix createContainer render dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [v0.7.3]
 
+- **Bugfix** `createContainer` dispatcher not properly updating on mutation events after a initial mutation
+
 # Released
 
 ## [v0.7.2](https://github.com/netarc/refrax/compare/v0.7.1...v0.7.2)

--- a/src/__tests__/createContainer.spec.ts
+++ b/src/__tests__/createContainer.spec.ts
@@ -461,6 +461,56 @@ describe('RefraxContainer', () => {
       expect(onFinish.callCount).to.equal(0);
     });
 
+    describe('when mutated', () => {
+      it('should correctly propagate', () => {
+        const onMutate = spy();
+        const wrapper = mount(React.createElement(TestComponentContainer, {
+          refrax: {
+            createUser: actionCreateUser
+          }
+        }, null));
+
+        expect(wrapper.instance().state.attachments)
+          .to.have.all.keys([
+            'createUser'
+          ])
+          .to.deep.match({
+            createUser: RefraxActionEntity
+          });
+
+        const createUserAction = wrapper.instance().state.attachments.createUser;
+        createUserAction.on('mutated', onMutate);
+
+        resetSpies();
+
+        expect(onMutate.callCount).to.equal(0);
+
+        createUserAction.set('foo', 123);
+
+        return delay_for()()
+          .then(() => {
+            expect(spyTCC_componentWillMount.callCount).to.equal(0);
+            expect(spyTCC_render.callCount).to.equal(1);
+            expect(spyTC_componentWillMount.callCount).to.equal(0);
+            expect(spyTC_componentWillReceiveProps.callCount).to.equal(1);
+            expect(spyTC_render.callCount).to.equal(1);
+            expect(onMutate.callCount).to.equal(1);
+
+            createUserAction.set('bar', 123);
+
+            return delay_for()()
+              .then(() => {
+                expect(spyTCC_componentWillMount.callCount).to.equal(0);
+                expect(spyTCC_render.callCount).to.equal(2);
+                expect(spyTC_componentWillMount.callCount).to.equal(0);
+                expect(spyTC_componentWillReceiveProps.callCount).to.equal(2);
+                expect(spyTC_render.callCount).to.equal(2);
+                expect(onMutate.callCount).to.equal(2);
+              });
+            });
+      });
+    });
+
     describe('when invoked', () => {
       it('should correctly propagate', () => {
         const onStart = spy();

--- a/src/createContainer.tsx
+++ b/src/createContainer.tsx
@@ -78,9 +78,10 @@ const renderDispatcherFor = (component: IRefraxContainerComponent) => {
 
   return (debounced: boolean) => {
     if (debounced === true) {
-      if (timeout == null) {
+      if (timeout === null) {
         timeout = setTimeout(() => {
-          if (timeout != null) {
+          if (timeout !== null) {
+            timeout = null;
             renderComponent(component);
           }
         }, delayRenderDebounceTime);


### PR DESCRIPTION
This PR fixes an issue where `createContainer` would fail to dispatch render sequential debounced updates.